### PR TITLE
ssl.cmake: fix version regex for OpenSSL 1.0.2.

### DIFF
--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -166,7 +166,7 @@ MACRO (MYSQL_CHECK_SSL)
     # Encoded as MNNFFPPS: major minor fix patch status
     FILE(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h"
       OPENSSL_VERSION_NUMBER
-      REGEX "^#define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9].*"
+      REGEX "^#[\t ]+define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9].*"
     )
     STRING(REGEX REPLACE
       "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9]).*$" "\\1"


### PR DESCRIPTION
OpenSSL 1.0.2 has whitespace between the `#` and `define` so make the regex more liberal to match it accordingly.

Should be backported to 5.6, 5.5 branches too.

Thanks!

CC https://github.com/Homebrew/homebrew/issues/36205 @DomT4